### PR TITLE
Refresh database on save

### DIFF
--- a/Assets/Scripts/ViconNexusUnityStream/SubjectDataManager.cs
+++ b/Assets/Scripts/ViconNexusUnityStream/SubjectDataManager.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.ObjectModel;
+using UnityEditor;
 
 namespace ubco.ovilab.ViconUnityStream
 {
@@ -156,6 +157,8 @@ namespace ubco.ovilab.ViconUnityStream
                 fileNameBase = fileNameBase + "_" + DateTime.Now.ToString("dd-MM-yy hh-mm-ss") + ".json";
                 pathToRecordedData = Path.Combine(pathToRecordedData, fileNameBase);
                 File.AppendAllTextAsync(pathToRecordedData, jsonData);
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
             }
         }
 


### PR DESCRIPTION
now the editor properly shows the asset on exiting playmode instead of requiring a manual refresh trigger

https://github.com/user-attachments/assets/20472ffd-1bed-4e1d-97d6-dbc2c1cacc0b

