### PR TITLE
moved hand properties to scriptable object data container

### DIFF
--- a/Assets/Scripts/ViconNexusUnityStream/CustomHandScript.cs
+++ b/Assets/Scripts/ViconNexusUnityStream/CustomHandScript.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using ubco.ovilab.ViconUnityStream.Utils;
 using UnityEngine;
 using UnityEngine.XR.Hands;
 using UnityEngine.Assertions;
@@ -26,18 +27,8 @@ namespace ubco.ovilab.ViconUnityStream
         [Tooltip("The radius of each joint to be reported by the xr hands. Joints not in this list will not report radius.")]
         private List<XRHandJointRadius> xrHandJointRadiiList = new();
 
-        public float baseNormalOffset = 0.001f;
-
-        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
-        [SerializeField] public float indexNormalOffset = 0f;
-        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
-        [SerializeField] public float middleNormalOffset = 0f;
-        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
-        [SerializeField] public float ringNormalOffset = 0f;
-        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
-        [SerializeField] public float littleNormalOffset = 0f;
-        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
-        [SerializeField] public float thumbNormalOffset = 0f;
+        [Tooltip("Properties of the hand to be configured"), SerializeField]
+        private HandProperties handProperties;
 
         public bool setPosition = true;
         public bool setScale = true;
@@ -608,15 +599,15 @@ namespace ubco.ovilab.ViconUnityStream
                         if (setPosition)
                         {
                             if (fingerId == finger_1)
-                                Bone.position += Bone.forward * (baseNormalOffset * (1 + thumbNormalOffset * 0.01f));
+                                Bone.position += Bone.forward * (handProperties.BaseNormalOffset * (1 + handProperties.ThumbNormalOffset * 0.01f));
                             else if (fingerId == finger_3)
-                                Bone.position += Bone.forward * (baseNormalOffset * (1 + middleNormalOffset * 0.01f));
+                                Bone.position += Bone.forward * (handProperties.BaseNormalOffset * (1 + handProperties.MiddleNormalOffset * 0.01f));
                             else if (fingerId == finger_4)
-                                Bone.position += Bone.forward * (baseNormalOffset * (1 + ringNormalOffset * 0.01f));
+                                Bone.position += Bone.forward * (handProperties.BaseNormalOffset * (1 + handProperties.RingNormalOffset * 0.01f));
                             else if (fingerId == finger_5)
-                                Bone.position += Bone.forward * (baseNormalOffset * (1 + littleNormalOffset * 0.01f));
+                                Bone.position += Bone.forward * (handProperties.BaseNormalOffset * (1 + handProperties.LittleNormalOffset * 0.01f));
                             else
-                                Bone.position += Bone.forward * (baseNormalOffset * (1 + indexNormalOffset * 0.01f));
+                                Bone.position += Bone.forward * (handProperties.BaseNormalOffset * (1 + handProperties.IndexNormalOffset * 0.01f));
                         }
 
                         if (segmentToJointMapping.ContainsKey(BoneName))

--- a/Assets/Scripts/ViconNexusUnityStream/Utils/HandProperties.cs
+++ b/Assets/Scripts/ViconNexusUnityStream/Utils/HandProperties.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+namespace ubco.ovilab.ViconUnityStream.Utils
+{
+    [CreateAssetMenu(fileName = "HandProperties", menuName = "ViconCustomSubject/HandProperties", order = 0)]
+    public class HandProperties : ScriptableObject
+    {
+        private float baseNormalOffset = 0.001f;
+
+        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
+        [SerializeField] private float indexNormalOffset = 0f;
+        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
+        [SerializeField] private float middleNormalOffset = 0f;
+        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
+        [SerializeField] private float ringNormalOffset = 0f;
+        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
+        [SerializeField] private float littleNormalOffset = 0f;
+        [Tooltip("Increasing or decreasing the normal offset value by a certain percentage.")] [Range(-100, 100)]
+        [SerializeField] private float thumbNormalOffset = 0f;
+
+        /// <summary>
+        /// Base normal offset in unity units to place hand from marker positions
+        /// </summary>
+        public float BaseNormalOffset
+        {
+            get => baseNormalOffset;
+            set => baseNormalOffset = value;
+        }
+
+        /// <summary>
+        /// Increasing or decreasing the normal offset value of the thumb by a certain percentage.
+        /// </summary>
+        public float ThumbNormalOffset
+        {
+            get => thumbNormalOffset;
+            set => thumbNormalOffset = value;
+        }
+
+        /// <summary>
+        /// Increasing or decreasing the normal offset value of the index finger by a certain percentage.
+        /// </summary>
+        public float IndexNormalOffset
+        {
+            get => indexNormalOffset;
+            set => indexNormalOffset = value;
+        }
+
+        /// <summary>
+        /// Increasing or decreasing the normal offset value of the middle finger by a certain percentage.
+        /// </summary>
+        public float MiddleNormalOffset
+        {
+            get => middleNormalOffset;
+            set => middleNormalOffset = value;
+        }
+
+        /// <summary>
+        /// Increasing or decreasing the normal offset value of the ring finger by a certain percentage.
+        /// </summary>
+        public float RingNormalOffset
+        {
+            get => ringNormalOffset;
+            set => ringNormalOffset = value;
+        }
+
+        /// <summary>
+        /// Increasing or decreasing the normal offset value of the little finger by a certain percentage.
+        /// </summary>
+        public float LittleNormalOffset
+        {
+            get => littleNormalOffset;
+            set => littleNormalOffset = value;
+        }
+    }
+}

--- a/Assets/Scripts/ViconNexusUnityStream/Utils/HandProperties.cs.meta
+++ b/Assets/Scripts/ViconNexusUnityStream/Utils/HandProperties.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 105894e3f052447a9ac26a82866a42cd
+timeCreated: 1740284763


### PR DESCRIPTION
the main purpose of this is two-fold:

- This allows maintaining separate configurations that should be trivial to switch between for different types of hands, rather than tweaking values in runtime.
    - Another benefit here is retaining the values after runtime, so a new asset can be created for a user, tuned for the user and it will persist between sessions.
- This is good for builds as well, whereby you can modify the instance of the asset in runtime (for tuning purposes), which will persist through the session. 
    - We could extend this functionality to write to json save files as well down the line if saving a config is preferable through multiple sessions